### PR TITLE
Simplified flow selection for clients by allowing setting flow type

### DIFF
--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/model/Request.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/model/Request.java
@@ -24,13 +24,16 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Generic request that contains a request type and arbitrary data bespoke to each request type.
+ * Generic request that at minimum contains a request type and optionally flow name and bespoke request data.
+ *
+ * If a flow name is set, the flow with that name will be explicitly used. If not set, the request type will be used to look up eligible flows
+ * and one will be selected either automatically or via user interaction.
  */
 public class Request extends BaseModel {
 
-    private final String requestFlow;
+    private final String requestType;
     private final AdditionalData requestData;
-    private String requestType;
+    private String flowName;
     private String deviceId;
     private String targetAppId;
 
@@ -40,48 +43,40 @@ public class Request extends BaseModel {
     }
 
     /**
-     * Initialise this request with a request flow and empty data.
+     * Initialise this request with a request type and empty data.
      *
-     * The request flow refers to what flow this request will be processed through.
+     * The request type will be used to assign the correct flow for this request.
+     *
+     * Please see {@link #setFlowName(String)} to explicitly specify what flow to use.
      *
      * See reference values in the documentation for possible values.
      *
-     * @param requestFlow The request type
+     * @param requestType The request type
      */
-    public Request(String requestFlow) {
-        this(requestFlow, new AdditionalData());
+    public Request(String requestType) {
+        this(requestType, new AdditionalData());
     }
 
     /**
-     * Initialise this request with a request flow and data.
+     * Initialise this request with a request type and data.
      *
-     * The request flow refers to what flow this request will be processed through.
+     * The request type will be used to assign the correct flow for this request.
+     *
+     * Please see {@link #setFlowName(String)} to explicitly specify what flow to use.
      *
      * See reference values in the documentation for possible values.
      *
-     * @param requestFlow The request type
+     * @param requestType The request type
      * @param requestData The data for the request
      */
-    public Request(String requestFlow, AdditionalData requestData) {
-        this(UUID.randomUUID().toString(), requestFlow, requestData);
+    public Request(String requestType, AdditionalData requestData) {
+        this(UUID.randomUUID().toString(), requestType, requestData);
     }
 
-    private Request(String id, String requestFlow, AdditionalData requestData) {
+    private Request(String id, String requestType, AdditionalData requestData) {
         super(id);
-        this.requestFlow = requestFlow;
+        this.requestType = requestType;
         this.requestData = requestData;
-    }
-
-    /**
-     * Get the request flow which refers to what flow this request will be processed through.
-     *
-     * For request type, see {@link #getRequestType()}.
-     *
-     * @return The request flow
-     */
-    @NonNull
-    public String getRequestFlow() {
-        return requestFlow;
     }
 
     /**
@@ -92,6 +87,29 @@ public class Request extends BaseModel {
     @NonNull
     public String getRequestType() {
         return requestType;
+    }
+
+    /**
+     * Explicitly set the name of the flow to process this request.
+     *
+     * This can and should be used in cases where there is more than one flow for the provided request type.
+     *
+     * @param flowName The name of the flow to use
+     */
+    public void setFlowName(String flowName) {
+        this.flowName = flowName;
+    }
+
+    /**
+     * Get the name of the flow which will process this request, if any.
+     *
+     * If not set, the request type will be used to map this to a flow.
+     *
+     * @return The request flow
+     */
+    @Nullable
+    public String getFlowName() {
+        return flowName;
     }
 
     /**
@@ -164,17 +182,6 @@ public class Request extends BaseModel {
         return requestData;
     }
 
-    /**
-     * Set the request type for this request.
-     *
-     * For internal use.
-     *
-     * @param requestType Request type
-     */
-    public void setRequestType(String requestType) {
-        this.requestType = requestType;
-    }
-
     @Override
     public String toJson() {
         return JsonConverter.serialize(this);
@@ -183,7 +190,7 @@ public class Request extends BaseModel {
     @Override
     public String toString() {
         return "Request{" +
-                "requestFlow='" + requestFlow + '\'' +
+                "flowName='" + flowName + '\'' +
                 ", requestData=" + requestData +
                 ", requestType='" + requestType + '\'' +
                 ", deviceId='" + deviceId + '\'' +
@@ -197,7 +204,7 @@ public class Request extends BaseModel {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         Request request = (Request) o;
-        return Objects.equals(requestFlow, request.requestFlow) &&
+        return Objects.equals(flowName, request.flowName) &&
                 Objects.equals(requestData, request.requestData) &&
                 Objects.equals(requestType, request.requestType) &&
                 Objects.equals(deviceId, request.deviceId) &&
@@ -207,7 +214,7 @@ public class Request extends BaseModel {
     @Override
     public int hashCode() {
 
-        return Objects.hash(super.hashCode(), requestFlow, requestData, requestType, deviceId, targetAppId);
+        return Objects.hash(super.hashCode(), flowName, requestData, requestType, deviceId, targetAppId);
     }
 
     public static Request fromJson(String json) {
@@ -218,11 +225,11 @@ public class Request extends BaseModel {
      * For internal use.
      *
      * @param id          Id
-     * @param requestFlow Request flow
+     * @param requestType Request flow
      * @param requestData Request data
      * @return Request
      */
-    public static Request fromExternalId(String id, String requestFlow, AdditionalData requestData) {
-        return new Request(id, requestFlow, requestData);
+    public static Request fromExternalId(String id, String requestType, AdditionalData requestData) {
+        return new Request(id, requestType, requestData);
     }
 }

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseApiService.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseApiService.java
@@ -27,10 +27,8 @@ import com.aevi.sdk.flow.stage.BaseStageModel;
 
 import io.reactivex.functions.Consumer;
 
-import static com.aevi.sdk.flow.constants.AppMessageTypes.FORCE_FINISH_MESSAGE;
-import static com.aevi.sdk.flow.constants.AppMessageTypes.REQUEST_MESSAGE;
-import static com.aevi.sdk.flow.constants.MessageErrors.ERROR_SERVICE_EXCEPTION;
-import static com.aevi.sdk.flow.constants.MessageErrors.ERROR_UNKNOWN_MESSAGE_TYPE;
+import static com.aevi.sdk.flow.constants.AppMessageTypes.*;
+import static com.aevi.sdk.flow.constants.MessageErrors.*;
 
 /**
  * Base service for all API service implementations.
@@ -142,8 +140,7 @@ public abstract class BaseApiService extends AbstractChannelService {
      * @param request            The request to be processed
      * @param flowStage          The flow stage this request is being called for
      */
-    protected abstract void processRequest(@NonNull ClientCommunicator clientCommunicator, @NonNull String request,
-                                                     @NonNull String flowStage);
+    protected abstract void processRequest(@NonNull ClientCommunicator clientCommunicator, @NonNull String request, @NonNull String flowStage);
 
     /**
      * Called externally when your application needs to abort what it is doing and finish anything that may be running including an Activity that you may have started.

--- a/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfoBuilder.java
+++ b/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfoBuilder.java
@@ -105,10 +105,14 @@ public class PaymentFlowServiceInfoBuilder {
     /**
      * Define custom request types that this service can handle.
      *
+     * Note that the names should follow camel case convention. "myType" is valid, but "my type", "my_type" or "MyType" etc are all invalid.
+     *
      * A service can via an implementation of {@link BaseGenericService} handle any custom request.
      *
      * These custom requests are identified via their type, which is set in the {@link com.aevi.sdk.flow.model.Request} and routed to the
      * service that has defined it as a supported custom type here.
+     *
+     * What data is required in the request, or available from the response, needs to be made available via documentation. See docs for details.
      *
      * @param customRequestTypes A list of string values representing custom request types
      * @return This builder
@@ -117,6 +121,9 @@ public class PaymentFlowServiceInfoBuilder {
     public PaymentFlowServiceInfoBuilder withCustomRequestTypes(String... customRequestTypes) {
         if (customRequestTypes != null) {
             this.customRequestTypes = new HashSet<>(Arrays.asList(customRequestTypes));
+            if (this.customRequestTypes.contains("payment")) {
+                throw new IllegalArgumentException("payment is not a valid custom type");
+            }
         }
         return this;
     }

--- a/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentBuilder.java
+++ b/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentBuilder.java
@@ -30,8 +30,9 @@ import static com.aevi.sdk.flow.util.Preconditions.checkArgument;
  */
 public class PaymentBuilder {
 
-    public static final String AEVI_POS_FLOW = "AEVI POS Flow";
+    public static final String AEVI_APPFLOW = "AEVI AppFlow";
 
+    private String flowType;
     private String flowName;
     private Amounts amounts;
     private Basket basket;
@@ -39,13 +40,14 @@ public class PaymentBuilder {
     private boolean splitEnabled;
     private Token cardToken;
     private AdditionalData additionalData = new AdditionalData();
-    private String source = AEVI_POS_FLOW;
+    private String source = AEVI_APPFLOW;
     private String deviceId;
 
     public PaymentBuilder() {
     }
 
     public PaymentBuilder(Payment paymentToCopyFrom) {
+        flowType = paymentToCopyFrom.getFlowType();
         flowName = paymentToCopyFrom.getFlowName();
         amounts = paymentToCopyFrom.getAmounts();
         basket = paymentToCopyFrom.getBasket();
@@ -58,17 +60,42 @@ public class PaymentBuilder {
     }
 
     /**
-     * Set what flow to use for processing this payment.
+     * Set what flow to use based on flow type.
+     *
+     * As AppFlow supports multiple flows per type, assigning a flow based on type only may lead to a runtime selection dialog for the merchant.
+     *
+     * Ideally, for any production scenarios, use {@link #withPaymentFlow(String, String)} to specify the name of the flow as well to ensure
+     * a good experience for the merchant. See docs for more clarification on this.
      *
      * The flow will determine what stages the payment goes through and what applications get called. Please see documentation for more details.
      *
      * See {@link PaymentSettings} for retrieving flow information.
      *
+     * @param flowType The flow type
+     * @return This builder
+     */
+    @NonNull
+    public PaymentBuilder withPaymentFlow(String flowType) {
+        this.flowType = flowType;
+        return this;
+    }
+
+    /**
+     * Set what flow to use based on flow type and name.
+     *
+     * This ensures that the intended flow is used in the case of multiple flows for the provided type.
+     *
+     * The flow will determine what stages the payment goes through and what applications get called. Please see documentation for more details.
+     *
+     * See {@link PaymentSettings} for retrieving flow information.
+     *
+     * @param flowType The flow type
      * @param flowName The name of the flow to use
      * @return This builder
      */
     @NonNull
-    public PaymentBuilder withPaymentFlow(String flowName) {
+    public PaymentBuilder withPaymentFlow(String flowType, String flowName) {
+        this.flowType = flowType;
         this.flowName = flowName;
         return this;
     }
@@ -203,7 +230,7 @@ public class PaymentBuilder {
      */
     @NonNull
     public Payment build() {
-        checkArgument(flowName != null, "Flow name must be set");
+        checkArgument(flowType != null, "Flow type must be set");
         checkArgument(amounts != null, "Amounts must be set");
         if (cardToken != null && splitEnabled) {
             throw new IllegalArgumentException("Card token can not be set for a split payment as token relates to only one customer");
@@ -211,6 +238,6 @@ public class PaymentBuilder {
         if (basket != null && basket.getTotalBasketValue() != amounts.getBaseAmountValue()) {
             throw new IllegalArgumentException("The basket total value must match base amounts value");
         }
-        return new Payment(flowName, amounts, basket, customer, splitEnabled, cardToken, additionalData, source, deviceId);
+        return new Payment(flowType, flowName, amounts, basket, customer, splitEnabled, cardToken, additionalData, source, deviceId);
     }
 }

--- a/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/config/FlowConfigurations.java
+++ b/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/config/FlowConfigurations.java
@@ -15,6 +15,7 @@
 package com.aevi.sdk.pos.flow.model.config;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.aevi.sdk.flow.model.config.FlowConfig;
 
@@ -23,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.reactivex.Observable;
+import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 
 /**
@@ -65,6 +67,36 @@ public class FlowConfigurations {
     @NonNull
     public FlowConfig getFlowConfiguration(final String flowName) {
         return fromName(flowName);
+    }
+
+    /**
+     * Get supported flow types for the given request class.
+     *
+     * If this should return flow types for initiating generic {@link com.aevi.sdk.flow.model.Request}, then use {@link FlowConfig#REQUEST_CLASS_GENERIC}
+     *
+     * If this should return flow types for initiating {@link com.aevi.sdk.pos.flow.model.Payment}, then use {@link FlowConfig#REQUEST_CLASS_PAYMENT}
+     *
+     * If null is passed, all types will be returned.
+     *
+     * @param requestClass {@link FlowConfig#REQUEST_CLASS_GENERIC}, {@link FlowConfig#REQUEST_CLASS_PAYMENT} or null for all types
+     * @return A list of supported flow types
+     */
+    public List<String> getFlowTypes(@Nullable final String requestClass) {
+        return stream()
+                .filter(new Predicate<FlowConfig>() {
+                    @Override
+                    public boolean test(FlowConfig flowConfig) throws Exception {
+                        return requestClass == null || flowConfig.getRequestClass().equals(requestClass);
+                    }
+                })
+                .map(new Function<FlowConfig, String>() {
+                    @Override
+                    public String apply(FlowConfig flowConfig) throws Exception {
+                        return flowConfig.getType();
+                    }
+                })
+                .toList()
+                .blockingGet();
     }
 
     /**

--- a/payment-initiation-api/src/test/java/com/aevi/sdk/pos/flow/model/PaymentBuilderTest.java
+++ b/payment-initiation-api/src/test/java/com/aevi/sdk/pos/flow/model/PaymentBuilderTest.java
@@ -43,13 +43,14 @@ public class PaymentBuilderTest {
     public void shouldBuildPaymentWithCorrectSetup() throws Exception {
         Basket basket = new Basket("test", new BasketItemBuilder().generateRandomId().withLabel("bla").withAmount(1000).build());
         Payment payment = new PaymentBuilder()
-                .withPaymentFlow("sale")
+                .withPaymentFlow("sale", "monkeySale")
                 .withAmounts(new Amounts(1000, "GBP"))
                 .withBasket(basket)
                 .withSplitEnabled(true)
                 .build();
 
-        assertThat(payment.getFlowName()).isEqualTo("sale");
+        assertThat(payment.getFlowType()).isEqualTo("sale");
+        assertThat(payment.getFlowName()).isEqualTo("monkeySale");
         assertThat(payment.getAmounts()).isEqualTo(new Amounts(1000, "GBP"));
         assertThat(payment.isSplitEnabled()).isTrue();
         assertThat(payment.getBasket()).isNotNull();

--- a/payment-initiation-api/src/test/java/com/aevi/sdk/pos/flow/model/PaymentTest.java
+++ b/payment-initiation-api/src/test/java/com/aevi/sdk/pos/flow/model/PaymentTest.java
@@ -45,9 +45,9 @@ public class PaymentTest {
 
     private void assertValues(Payment payment, long amount, String currency, String type) {
         assertThat(payment).isNotNull();
-        assertThat(payment.getAmounts()).isEqualTo(new com.aevi.sdk.pos.flow.model.Amounts(amount, currency));
+        assertThat(payment.getAmounts()).isEqualTo(new Amounts(amount, currency));
         assertThat(payment.getAmounts().getCurrency()).isEqualTo(currency);
-        assertThat(payment.getFlowName()).isEqualTo(type);
+        assertThat(payment.getFlowType()).isEqualTo(type);
     }
 
     private void assertArrayOfOptions(Payment result, String key, String... types) {

--- a/sample-commons/src/main/java/com/aevi/sdk/pos/flow/sample/AmountFormatter.java
+++ b/sample-commons/src/main/java/com/aevi/sdk/pos/flow/sample/AmountFormatter.java
@@ -14,14 +14,29 @@
 
 package com.aevi.sdk.pos.flow.sample;
 
-import java.text.DecimalFormat;
+import java.math.BigDecimal;
 import java.util.Currency;
 
 public class AmountFormatter {
 
-    private static final DecimalFormat TWO_PLACES = new DecimalFormat("0.00");
-
-    public static String formatAmount(String currency, long amount) {
-        return Currency.getInstance(currency).getSymbol() + TWO_PLACES.format(amount / (double) 100);
+    /**
+     * Format amount to a readable format, taking currency sub-unit fractions into account
+     */
+    public static String formatAmount(String currencyCode, long amountValue) {
+        if (currencyCode != null && amountValue > 0) {
+            String symbol;
+            int subUnitFractions;
+            try {
+                Currency currency = Currency.getInstance(currencyCode);
+                symbol = currency.getSymbol();
+                subUnitFractions = currency.getDefaultFractionDigits();
+            } catch (Throwable t) {
+                symbol = currencyCode;
+                subUnitFractions = 2;
+            }
+            return symbol + BigDecimal.valueOf(amountValue).movePointLeft(subUnitFractions).toString();
+        } else {
+            return "0.00";
+        }
     }
 }

--- a/sample-commons/src/main/java/com/aevi/sdk/pos/flow/sample/ui/ModelDetailsFragment.java
+++ b/sample-commons/src/main/java/com/aevi/sdk/pos/flow/sample/ui/ModelDetailsFragment.java
@@ -94,7 +94,9 @@ public class ModelDetailsFragment extends BaseObservableFragment implements Mode
     private void addPaymentOverview(Payment payment) {
         List<Pair<String, String>> paymentInfo = new ArrayList<>();
         paymentInfo.add(getStringPair(R.string.id, payment.getId()));
-        paymentInfo.add(getStringPair(R.string.flow_name, payment.getFlowName()));
+        if (payment.getFlowName() != null) {
+            paymentInfo.add(getStringPair(R.string.flow_name, payment.getFlowName()));
+        }
         if (payment.getFlowType() != null) {
             paymentInfo.add(getStringPair(R.string.transaction_type, payment.getFlowType()));
         }
@@ -108,7 +110,9 @@ public class ModelDetailsFragment extends BaseObservableFragment implements Mode
         reset();
         List<Pair<String, String>> requestInfo = new ArrayList<>();
         requestInfo.add(getStringPair(R.string.id, request.getId()));
-        requestInfo.add(getStringPair(R.string.request_flow, request.getRequestFlow()));
+        if (request.getFlowName() != null) {
+            requestInfo.add(getStringPair(R.string.request_flow, request.getFlowName()));
+        }
         if (request.getRequestType() != null) {
             requestInfo.add(getStringPair(R.string.request_type, request.getRequestType()));
         }
@@ -226,6 +230,10 @@ public class ModelDetailsFragment extends BaseObservableFragment implements Mode
     public void showPaymentResponse(PaymentResponse paymentResponse) {
         reset();
         List<Pair<String, String>> responseInfo = new ArrayList<>();
+        if (paymentResponse.getOriginatingPayment().getFlowName() != null) {
+            responseInfo.add(getStringPair(R.string.request_flow, paymentResponse.getOriginatingPayment().getFlowName()));
+        }
+        responseInfo.add(getStringPair(R.string.flow_type, paymentResponse.getOriginatingPayment().getFlowType()));
         responseInfo.add(getStringPair(R.string.outcome, paymentResponse.getOutcome().name()));
         responseInfo.add(getStringPair(R.string.failure_reason, paymentResponse.getFailureReason().name()));
         if (paymentResponse.getFailureMessage() != null) {
@@ -261,7 +269,9 @@ public class ModelDetailsFragment extends BaseObservableFragment implements Mode
     public void showResponse(Response response) {
         reset();
         List<Pair<String, String>> responseInfo = new ArrayList<>();
-        responseInfo.add(getStringPair(R.string.request_flow, response.getOriginatingRequest().getRequestFlow()));
+        if (response.getOriginatingRequest().getFlowName() != null) {
+            responseInfo.add(getStringPair(R.string.request_flow, response.getOriginatingRequest().getFlowName()));
+        }
         if (response.getOriginatingRequest().getRequestType() != null) {
             responseInfo.add(getStringPair(R.string.request_type, response.getOriginatingRequest().getRequestType()));
         }

--- a/sample-commons/src/main/res/values/strings.xml
+++ b/sample-commons/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="transaction_type">Transaction type</string>
     <string name="flow_name">Flow name</string>
+    <string name="flow_type">Flow type</string>
     <string name="request_type">Request type</string>
     <string name="request_flow">Request flow</string>
     <string name="overall_status">All transactions approved</string>


### PR DESCRIPTION
Previously we enforced clients set the name of a flow, which was fairly inconvenient for the
majority of cases. This allows the type to be set instead, and FPS maps to available flows.

Also fixes issue with subunits.