### PR TITLE
Re-introduced the ability to set supported flow types

### DIFF
--- a/FlowServiceSample/src/main/AndroidManifest.xml
+++ b/FlowServiceSample/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
             </intent-filter>
         </service>
 
+        <!--Standard flow services do not need to extend ActivityProxyService. This sample does it to enable the stage enable/disable controls.-->
         <service
             android:name=".service.FlowActivityProxyService"
             android:exported="true">

--- a/FlowServiceSample/src/main/java/com/aevi/sdk/pos/flow/flowservicesample/PaymentFlowServiceInfoProvider.java
+++ b/FlowServiceSample/src/main/java/com/aevi/sdk/pos/flow/flowservicesample/PaymentFlowServiceInfoProvider.java
@@ -21,6 +21,8 @@ import com.aevi.sdk.pos.flow.model.PaymentFlowServiceInfo;
 import com.aevi.sdk.pos.flow.model.PaymentFlowServiceInfoBuilder;
 import com.aevi.sdk.pos.flow.provider.BasePaymentFlowServiceInfoProvider;
 
+import static com.aevi.sdk.flow.constants.FlowTypes.FLOW_TYPE_SALE;
+
 public class PaymentFlowServiceInfoProvider extends BasePaymentFlowServiceInfoProvider {
 
     @Override
@@ -30,6 +32,7 @@ public class PaymentFlowServiceInfoProvider extends BasePaymentFlowServiceInfoPr
                 .withDisplayName("Flow Service Sample")
                 .withCanAdjustAmounts(true)
                 .withCanPayAmounts(true, PaymentMethods.LOYALTY_POINTS, PaymentMethods.GIFT_CARD, PaymentMethods.CASH)
+                .withSupportedFlowTypes(FLOW_TYPE_SALE)
                 .withCustomRequestTypes(ShowLoyaltyPointsBalanceService.SHOW_LOYALTY_POINTS_REQUEST)
                 .build(getContext());
     }

--- a/FlowServiceSample/src/main/java/com/aevi/sdk/pos/flow/flowservicesample/service/FlowActivityProxyService.java
+++ b/FlowServiceSample/src/main/java/com/aevi/sdk/pos/flow/flowservicesample/service/FlowActivityProxyService.java
@@ -21,6 +21,9 @@ import com.aevi.sdk.flow.service.ClientCommunicator;
 import com.aevi.sdk.pos.flow.flowservicesample.settings.ServiceStateHandler;
 import com.aevi.sdk.pos.flow.service.ActivityProxyService;
 
+/**
+ * Standard flow services do not need to extend ActivityProxyService. This sample does it to enable the stage enable/disable controls.
+ */
 public class FlowActivityProxyService extends ActivityProxyService {
 
     @Override

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/adapter/FlowServiceInfoAdapter.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/adapter/FlowServiceInfoAdapter.java
@@ -64,6 +64,9 @@ public class FlowServiceInfoAdapter extends BaseServiceInfoAdapter<PaymentFlowSe
             case R.string.service_label_request_types:
                 value = getSetValue(info.getCustomRequestTypes());
                 break;
+            case R.string.service_label_flow_types:
+                value = getSetValue(info.getSupportedFlowTypes());
+                break;
         }
         holder.value.setText(value);
     }

--- a/PaymentInitiationSample/src/main/res/values/strings.xml
+++ b/PaymentInitiationSample/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="service_label_app_version">Application Version</string>
     <string name="service_label_api_version">API Version</string>
     <string name="service_label_payment_methods">Payment methods</string>
+    <string name="service_label_flow_types">Flow types</string>
     <string name="service_label_request_types">Custom request types</string>
     <string name="service_label_currencies">Currencies</string>
     <string name="service_label_transaction_types">Transaction types</string>
@@ -144,31 +145,13 @@
     </string>
     <string name="choose_a_transaction_flow">Choose a transaction flow</string>
 
-    <array name="payment_service_labels">
-        <item>@string/service_label_id</item>
-        <item>@string/service_label_vendor</item>
-        <item>@string/service_label_app_version</item>
-        <item>@string/service_label_api_version</item>
-        <item>@string/ps_label_terminal_id</item>
-        <item>@string/ps_label_merchant_ids</item>
-        <item>@string/service_label_payment_methods</item>
-        <item>@string/ps_label_default_currency</item>
-        <item>@string/service_label_currencies</item>
-        <item>@string/service_label_request_types</item>
-        <item>@string/service_label_transaction_types</item>
-        <item>@string/ps_label_manual_entry</item>
-        <item>@string/service_label_accessible_mode</item>
-        <item>@string/ps_label_print_receipts</item>
-        <item>@string/ps_label_card_reading</item>
-        <item>@string/service_label_supported_data_keys</item>
-    </array>
-
     <array name="flow_service_labels">
         <item>@string/service_label_id</item>
         <item>@string/service_label_vendor</item>
         <item>@string/service_label_app_version</item>
         <item>@string/service_label_api_version</item>
         <item>@string/fs_label_stages</item>
+        <item>@string/service_label_flow_types</item>
         <item>@string/service_label_request_types</item>
         <item>@string/service_label_accessible_mode</item>
         <item>@string/fs_label_can_adjust_amounts</item>

--- a/PaymentServiceSample/src/main/java/com/aevi/sdk/pos/flow/paymentservicesample/PaymentServiceInfoProvider.java
+++ b/PaymentServiceSample/src/main/java/com/aevi/sdk/pos/flow/paymentservicesample/PaymentServiceInfoProvider.java
@@ -21,6 +21,8 @@ import com.aevi.sdk.pos.flow.model.PaymentFlowServiceInfoBuilder;
 import com.aevi.sdk.pos.flow.paymentservicesample.util.IdProvider;
 import com.aevi.sdk.pos.flow.provider.BasePaymentFlowServiceInfoProvider;
 
+import static com.aevi.sdk.flow.constants.FlowTypes.*;
+
 public class PaymentServiceInfoProvider extends BasePaymentFlowServiceInfoProvider {
 
     @Override
@@ -35,6 +37,7 @@ public class PaymentServiceInfoProvider extends BasePaymentFlowServiceInfoProvid
                 .withCanPayAmounts(true, supportedPaymentMethods)
                 .withSupportedCurrencies(supportedCurrencies)
                 .withDefaultCurrency(supportedCurrencies[0])
+                .withSupportedFlowTypes(FLOW_TYPE_SALE, FLOW_TYPE_REFUND, FLOW_TYPE_REVERSAL, FLOW_TYPE_TOKENISATION)
                 .withLogicalDeviceId(IdProvider.getTerminalId())
                 .withMerchants(new Merchant(IdProvider.getMerchantId(), IdProvider.getMerchantName()))
                 .withManualEntrySupport(false)

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/model/BaseServiceInfo.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/model/BaseServiceInfo.java
@@ -35,6 +35,7 @@ public abstract class BaseServiceInfo extends BaseModel {
     private final String apiVersion;
     private final String displayName;
     private final boolean hasAccessibilityMode;
+    private final Set<String> supportedFlowTypes;
     private final Set<String> customRequestTypes;
     private final Set<String> supportedDataKeys;
     private final AdditionalData additionalInfo;
@@ -45,11 +46,11 @@ public abstract class BaseServiceInfo extends BaseModel {
     // Default constructor for deserialisation
     protected BaseServiceInfo() {
         this("", "", "", "", "", "", "", false,
-                null, null, null);
+                null, null, null, null);
     }
 
     protected BaseServiceInfo(String id, String packageName, String vendor, String logicalDeviceId, String serviceVersion, String apiVersion,
-                              String displayName, boolean hasAccessibilityMode, Set<String> customRequestTypes,
+                              String displayName, boolean hasAccessibilityMode, Set<String> supportedFlowTypes, Set<String> customRequestTypes,
                               Set<String> supportedDataKeys, AdditionalData additionalInfo) {
         super(id);
         this.packageName = packageName;
@@ -59,6 +60,7 @@ public abstract class BaseServiceInfo extends BaseModel {
         this.apiVersion = apiVersion;
         this.displayName = displayName;
         this.hasAccessibilityMode = hasAccessibilityMode;
+        this.supportedFlowTypes = supportedFlowTypes != null ? supportedFlowTypes : new HashSet<String>();
         this.customRequestTypes = customRequestTypes != null ? customRequestTypes : new HashSet<String>();
         this.supportedDataKeys = supportedDataKeys != null ? supportedDataKeys : new HashSet<String>();
         this.additionalInfo = additionalInfo != null ? additionalInfo : new AdditionalData();
@@ -133,11 +135,37 @@ public abstract class BaseServiceInfo extends BaseModel {
     }
 
     /**
-     * Gets an array of the supported request types, indicating what type of requests it can handle.
+     * Get the list of supported pre-defined flow types.
      *
-     * See reference values in the documentation for possible values.
+     * See full list of supported flow types on the AppFlow wiki. Each pre-defined flow type will have a statically defined flow configuration
+     * associated with it, if supported on the current device.
      *
-     * @return array of request types supported by the service
+     * Note that what flow types are available to clients is entirely determined by the flow configurations and not what flow services reports.
+     * Instead, this is used to ensure applications can handle flows they have been assigned to and for various other internal uses.
+     *
+     * @return The set of supported pre-defined flow types
+     */
+    @NonNull
+    public Set<String> getSupportedFlowTypes() {
+        return supportedFlowTypes;
+    }
+
+    /**
+     * Check whether this service supports the given flow type.
+     *
+     * @param flowType The flow type to check if supported
+     * @return True if supported, false otherwise
+     */
+    public boolean supportsFlowType(String flowType) {
+        return supportedFlowTypes.size() > 0 && ComparisonUtil.stringCollectionContainsIgnoreCase(supportedFlowTypes, flowType);
+    }
+
+    /**
+     * Get the list of custom/bespoke request types that this service has defined.
+     *
+     * A custom request type is a type unique to a service for which a special type of generic flow is generated dynamically.
+     *
+     * @return The set of request types supported by the service
      */
     @NonNull
     public Set<String> getCustomRequestTypes() {
@@ -289,21 +317,24 @@ public abstract class BaseServiceInfo extends BaseModel {
         if (!super.equals(o)) return false;
         BaseServiceInfo that = (BaseServiceInfo) o;
         return hasAccessibilityMode == that.hasAccessibilityMode &&
+                enabled == that.enabled &&
                 Objects.equals(packageName, that.packageName) &&
                 Objects.equals(vendor, that.vendor) &&
                 Objects.equals(logicalDeviceId, that.logicalDeviceId) &&
                 Objects.equals(serviceVersion, that.serviceVersion) &&
                 Objects.equals(apiVersion, that.apiVersion) &&
                 Objects.equals(displayName, that.displayName) &&
+                Objects.equals(supportedFlowTypes, that.supportedFlowTypes) &&
                 Objects.equals(customRequestTypes, that.customRequestTypes) &&
                 Objects.equals(supportedDataKeys, that.supportedDataKeys) &&
                 Objects.equals(additionalInfo, that.additionalInfo) &&
-                Objects.equals(stages, that.stages);
+                Objects.equals(stages, that.stages) &&
+                Objects.equals(flowAndStagesDefinitions, that.flowAndStagesDefinitions);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(super.hashCode(), packageName, vendor, logicalDeviceId, serviceVersion, apiVersion, displayName, hasAccessibilityMode, customRequestTypes, supportedDataKeys, additionalInfo, stages);
+        return Objects.hash(super.hashCode(), packageName, vendor, logicalDeviceId, serviceVersion, apiVersion, displayName, hasAccessibilityMode, supportedFlowTypes, customRequestTypes, supportedDataKeys, additionalInfo, enabled, stages, flowAndStagesDefinitions);
     }
 }

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/model/config/FpsSettings.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/model/config/FpsSettings.java
@@ -30,6 +30,7 @@ public class FpsSettings implements Jsonable {
     public static final boolean ALWAYS_ALLOW_DYNAMIC_SELECT_DEFAULT = false;
     public static final boolean ABORT_ON_FLOW_APP_ERROR_DEFAULT = false;
     public static final boolean ABORT_ON_PAYMENT_APP_ERROR_DEFAULT = false;
+    public static final boolean FILTER_FLOW_SERVICES_BY_FLOW_TYPE_DEFAULT = true;
 
     public static final int SPLIT_RESPONSE_TIMEOUT_SECONDS_DEFAULT = 1200;
     public static final int FLOW_RESPONSE_TIMEOUT_SECONDS_DEFAULT = 120;
@@ -49,6 +50,8 @@ public class FpsSettings implements Jsonable {
 
     private boolean allowAccessViaStatusBar = ALLOW_ACCESS_STATUS_BAR_DEFAULT;
     private boolean alwaysAllowDynamicSelect = ALWAYS_ALLOW_DYNAMIC_SELECT_DEFAULT;
+
+    private boolean filterServicesByFlowType = FILTER_FLOW_SERVICES_BY_FLOW_TYPE_DEFAULT;
 
     /**
      * Check whether multi-device support is enabled.
@@ -306,6 +309,32 @@ public class FpsSettings implements Jsonable {
         this.alwaysAllowDynamicSelect = alwaysAllowDynamicSelect;
     }
 
+    /**
+     * Check whether or not FPS should filter flow services based on their reported type and the type of the flow.
+     *
+     * If true, services that do not explicitly report a type as supported will not be called for flows with that type.
+     *
+     * If false, FPS will always call flow services even if they don't report types, or the flow type is not supported by that service.
+     *
+     * @return True to enable FPS filtering, false otherwise
+     */
+    public boolean shouldFilterServicesByFlowType() {
+        return filterServicesByFlowType;
+    }
+
+    /**
+     * Set whether or not FPS should filter flow services based on their reported type and the type of the flow.
+     *
+     * If true, services that do not explicitly report a type as supported will not be called for flows with that type.
+     *
+     * If false, FPS will always call flow services even if they don't report types, or the flow type is not supported by that service.
+     *
+     * @param filterServicesByFlowType True to enable FPS filtering, false otherwise
+     */
+    public void setFilterServicesByFlowType(boolean filterServicesByFlowType) {
+        this.filterServicesByFlowType = filterServicesByFlowType;
+    }
+
     public static FpsSettings fromJson(String json) {
         return JsonConverter.deserialize(json, FpsSettings.class);
     }
@@ -329,12 +358,13 @@ public class FpsSettings implements Jsonable {
                 shouldAbortOnFlowAppError == that.shouldAbortOnFlowAppError &&
                 shouldAbortOnPaymentError == that.shouldAbortOnPaymentError &&
                 allowAccessViaStatusBar == that.allowAccessViaStatusBar &&
-                alwaysAllowDynamicSelect == that.alwaysAllowDynamicSelect;
+                alwaysAllowDynamicSelect == that.alwaysAllowDynamicSelect &&
+                filterServicesByFlowType == that.filterServicesByFlowType;
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(isMultiDevice, isCurrencyChangeAllowed, splitResponseTimeoutSeconds, flowResponseTimeoutSeconds, paymentResponseTimeoutSeconds, appOrDeviceSelectionTimeoutSeconds, shouldAbortOnFlowAppError, shouldAbortOnPaymentError, allowAccessViaStatusBar, alwaysAllowDynamicSelect);
+        return Objects.hash(isMultiDevice, isCurrencyChangeAllowed, splitResponseTimeoutSeconds, flowResponseTimeoutSeconds, paymentResponseTimeoutSeconds, appOrDeviceSelectionTimeoutSeconds, shouldAbortOnFlowAppError, shouldAbortOnPaymentError, allowAccessViaStatusBar, alwaysAllowDynamicSelect, filterServicesByFlowType);
     }
 }

--- a/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfoBuilder.java
+++ b/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfoBuilder.java
@@ -21,6 +21,7 @@ import android.support.annotation.NonNull;
 import com.aevi.sdk.flow.model.AdditionalData;
 import com.aevi.sdk.flow.service.BaseGenericService;
 import com.aevi.sdk.pos.flow.PaymentFlowServiceApi;
+import com.aevi.sdk.pos.flow.service.BasePaymentFlowService;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,6 +41,7 @@ public class PaymentFlowServiceInfoBuilder {
     private String defaultCurrency;
     private Set<String> paymentMethods;
     private Set<String> supportedCurrencies;
+    private Set<String> supportedFlowTypes;
     private Set<String> customRequestTypes;
     private Set<String> supportedDataKeys;
     private boolean canAdjustAmounts;
@@ -103,16 +105,42 @@ public class PaymentFlowServiceInfoBuilder {
     }
 
     /**
-     * Define custom request types that this service can handle.
+     * Set which of the pre-defined flow types your service supports.
      *
-     * Note that the names should follow camel case convention. "myType" is valid, but "my type", "my_type" or "MyType" etc are all invalid.
+     * See full list of supported flow types on the AppFlow wiki. Each pre-defined flow type will have a statically defined flow configuration
+     * associated with it, if supported on the current device.
      *
-     * A service can via an implementation of {@link BaseGenericService} handle any custom request.
+     * Note that what flow types are available to clients is entirely determined by the flow configurations and not what flow services reports.
+     * Instead, this is used to ensure applications can handle flows they have been assigned to and for various other internal uses.
      *
-     * These custom requests are identified via their type, which is set in the {@link com.aevi.sdk.flow.model.Request} and routed to the
-     * service that has defined it as a supported custom type here.
+     * If you leave this empty, your service will always be called for any type and it is up to your service to handle unsupported types.
      *
-     * What data is required in the request, or available from the response, needs to be made available via documentation. See docs for details.
+     * For defining your own, custom/bespoke, types, please see {@link #withCustomRequestTypes(String...)}.
+     *
+     * @param flowTypes The list of supported pre-defined flow types
+     * @return This builder
+     */
+    @NonNull
+    public PaymentFlowServiceInfoBuilder withSupportedFlowTypes(String... flowTypes) {
+        if (flowTypes != null) {
+            this.supportedFlowTypes = new HashSet<>(Arrays.asList(flowTypes));
+        }
+        return this;
+    }
+
+    /**
+     * Define custom request types that this service can process.
+     *
+     * A custom request type is a type unique to your service for which a special type of generic flow is generated dynamically.
+     *
+     * All such requests are called into your flow service via the generic routes, either via a {@link BaseGenericService} implementation, or
+     * from generic handling in a {@link BasePaymentFlowService} implementation.
+     *
+     * The type names should follow camel case convention. "myType" is valid, but "my type", "my_type" or "MyType" etc are all invalid.
+     *
+     * Clients can initiate a {@link com.aevi.sdk.flow.model.Request} with your custom request type for processing by your service.
+     *
+     * If there is any data required in the request, or available from the response, this needs to be made available via documentation.
      *
      * @param customRequestTypes A list of string values representing custom request types
      * @return This builder
@@ -307,7 +335,7 @@ public class PaymentFlowServiceInfoBuilder {
         checkNotNull(vendor, "Vendor must be set");
         checkNotNull(displayName, "Display name must be set");
         return new PaymentFlowServiceInfo(packageName, packageName, vendor, serviceVersion, apiVersion, displayName, supportsAccessibility,
-                customRequestTypes, supportedDataKeys, logicalDeviceId, canAdjustAmounts, canPayAmounts, defaultCurrency,
+                supportedFlowTypes, customRequestTypes, supportedDataKeys, logicalDeviceId, canAdjustAmounts, canPayAmounts, defaultCurrency,
                 supportedCurrencies, paymentMethods, additionalInfo);
     }
 

--- a/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/service/BasePaymentFlowService.java
+++ b/payment-flow-service-api/src/main/java/com/aevi/sdk/pos/flow/service/BasePaymentFlowService.java
@@ -10,18 +10,8 @@ import com.aevi.sdk.flow.service.ClientCommunicator;
 import com.aevi.sdk.flow.stage.GenericStageModel;
 import com.aevi.sdk.flow.stage.PostGenericStageModel;
 import com.aevi.sdk.pos.flow.PaymentFlowServiceApi;
-import com.aevi.sdk.pos.flow.model.Payment;
-import com.aevi.sdk.pos.flow.model.PaymentResponse;
-import com.aevi.sdk.pos.flow.model.SplitRequest;
-import com.aevi.sdk.pos.flow.model.TransactionRequest;
-import com.aevi.sdk.pos.flow.model.TransactionSummary;
-import com.aevi.sdk.pos.flow.stage.CardReadingModel;
-import com.aevi.sdk.pos.flow.stage.PostFlowModel;
-import com.aevi.sdk.pos.flow.stage.PostTransactionModel;
-import com.aevi.sdk.pos.flow.stage.PreFlowModel;
-import com.aevi.sdk.pos.flow.stage.PreTransactionModel;
-import com.aevi.sdk.pos.flow.stage.SplitModel;
-import com.aevi.sdk.pos.flow.stage.TransactionProcessingModel;
+import com.aevi.sdk.pos.flow.model.*;
+import com.aevi.sdk.pos.flow.stage.*;
 
 import static com.aevi.sdk.flow.constants.FlowStages.*;
 
@@ -112,7 +102,7 @@ public abstract class BasePaymentFlowService extends BaseApiService {
      *
      * @param model The model relevant for this stage
      */
-    protected void onPreTransaction(com.aevi.sdk.pos.flow.stage.PreTransactionModel model) {
+    protected void onPreTransaction(PreTransactionModel model) {
 
     }
 
@@ -184,9 +174,9 @@ public abstract class BasePaymentFlowService extends BaseApiService {
      *
      * The default implementation here will throw an exception. Clients can override to implement an alternative fallback behaviour.
      *
-     * @param flowStage       The flow stage that could not be mapped
+     * @param flowStage          The flow stage that could not be mapped
      * @param clientCommunicator The client message id
-     * @param request         The request
+     * @param request            The request
      */
     protected void onUnknownStage(String flowStage, ClientCommunicator clientCommunicator, String request) {
         throw new IllegalArgumentException("Unknown stage: " + flowStage);

--- a/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfo.java
+++ b/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/model/PaymentFlowServiceInfo.java
@@ -66,11 +66,11 @@ public class PaymentFlowServiceInfo extends BaseServiceInfo {
     }
 
     public PaymentFlowServiceInfo(String id, String packageName, String vendor, String serviceVersion, String apiVersion, String displayName,
-                                  boolean hasAccessibilityMode, Set<String> supportedRequestTypes, Set<String> supportedDataKeys, String logicalDeviceId,
-                                  boolean canAdjustAmounts, boolean canPayAmounts, String defaultCurrency,
-                                  Set<String> supportedCurrencies, Set<String> paymentMethods, AdditionalData additionalInfo) {
-        super(id, packageName, vendor, logicalDeviceId, serviceVersion, apiVersion, displayName, hasAccessibilityMode, supportedRequestTypes,
-                supportedDataKeys, additionalInfo);
+                                  boolean hasAccessibilityMode, Set<String> supportedFlowTypes, Set<String> supportedRequestTypes,
+                                  Set<String> supportedDataKeys, String logicalDeviceId, boolean canAdjustAmounts, boolean canPayAmounts,
+                                  String defaultCurrency, Set<String> supportedCurrencies, Set<String> paymentMethods, AdditionalData additionalInfo) {
+        super(id, packageName, vendor, logicalDeviceId, serviceVersion, apiVersion, displayName, hasAccessibilityMode, supportedFlowTypes,
+                supportedRequestTypes, supportedDataKeys, additionalInfo);
         this.canAdjustAmounts = canAdjustAmounts;
         this.canPayAmounts = canPayAmounts;
         this.defaultCurrency = defaultCurrency;


### PR DESCRIPTION
This replaces the previous getSupportedTransactionTypes() and getSupportedRequestTypes().

FPS will use this for filtering purposes, and providers can use to ensure we only add
apps to flows that they support.